### PR TITLE
Test if I can push to quay.io/acmiel-test

### DIFF
--- a/.tekton/multi-arch-konflux-sample-pull-request.yaml
+++ b/.tekton/multi-arch-konflux-sample-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads-stage/acmiel-tenant/multi-arch-konflux-sample:on-pr-{{revision}}
+    value: quay.io/acmiel-test/test:multi-arch-konflux-sample-on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/multi-arch-konflux-sample-pull-request.yaml
+++ b/.tekton/multi-arch-konflux-sample-pull-request.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: show-sbom
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04f15cbce548e1db7770eee3f155ccb2cc0140a6c371dc67e9a34d83673ea0c0
+          value: quay.io/acmiel-test/tekton-catalog/task-show-sbom:cosign-workaround
         - name: kind
           value: task
         resolver: bundles
@@ -248,7 +248,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:b9e92097becdb770689ed554b67e5fe9017576af252f317db51aba68d8894523
+          value: quay.io/acmiel-test/tekton-catalog/task-buildah-remote-oci-ta:cosign-workaround
         - name: kind
           value: task
         resolver: bundles
@@ -277,7 +277,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:70f2fe8ab9909c2bc8bb853ed5b880969f0de5022658f3af86f7dea15f95ff73
+          value: quay.io/acmiel-test/tekton-catalog/task-build-image-index:cosign-workaround
         - name: kind
           value: task
         resolver: bundles
@@ -301,7 +301,7 @@ spec:
         - name: name
           value: source-build-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:82d5951ad6348064ec33473eeb4d2fe6f7a2d3c8f3125927c04756ba35f251d2
+          value: quay.io/acmiel-test/tekton-catalog/task-source-build-oci-ta:cosign-workaround
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/multi-arch-konflux-sample-pull-request.yaml
+++ b/.tekton/multi-arch-konflux-sample-pull-request.yaml
@@ -30,7 +30,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:


### PR DESCRIPTION
I have a secret with

    {
        "auths": {
            "quay.io/acmiel-test": {
                "auth": "..."
            }
        }
    }

This will probably work for 'buildah push' but not 'cosign attach'